### PR TITLE
Adding a missing required field 'Action'

### DIFF
--- a/doc_source/authorizing-redshift-service.md
+++ b/doc_source/authorizing-redshift-service.md
@@ -180,7 +180,9 @@ A role that passes to another role must establish a trust relationship with the 
       "Effect": "Allow",
       "Principal": {
         "AWS": "arn:aws:iam::role/RoleA"
-      }
+      },
+      "Action": "sts:AssumeRole"
+    }
   ]
 }
 ```
@@ -195,7 +197,9 @@ The following trust policy establishes a trust relationship with the owner of `R
       "Effect": "Allow",
       "Principal": {
         "AWS": "arn:aws:iam::123456789012:root"
-      }
+      },
+      "Action": "sts:AssumeRole"
+    }
   ]
 }
 ```


### PR DESCRIPTION
While adding Trust Relationship, there is a required field called 'Action' which was not added to documentation.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
