### PR TITLE
Capitalize 'Internal Worktable' and 'S3'

### DIFF
--- a/doc_source/migrating-to-an-encrypted-cluster.md
+++ b/doc_source/migrating-to-an-encrypted-cluster.md
@@ -43,7 +43,7 @@ You enable encryption when you launch a cluster\. To migrate from an unencrypted
    count(distinct query) num_qs
    from stl_scan s
    where s.userid > 1
-   and   s.perm_table_name not in ('internal worktable','s3')
+   and   s.perm_table_name not in ('Internal Worktable','S3')
    group by tbl,
    perm_table_name) s on s.tbl = t.table_id
    where t."schema" not in ('pg_internal');


### PR DESCRIPTION
Description of issue:
The capitalization of 'Internal Worktable' and 'S3' provided in this Doc does not match with the version given in the amazon-redshift-utils repo. See: [here](https://github.com/awslabs/amazon-redshift-utils/blob/184c2ba7fd9d497027a831ca72e08fe09e79fd0b/src/AdminViews/v_get_tbl_scan_frequency.sql)

The incorrect capitalization is causing the query to return incorrect results. The where clause as written will not omit any rows. We can see this by running the subquery with an IN operation rather than NOT IN.

If you run a simplified form of the subquery originally given here with all lowercase in the where clause:
```
select count(*)
   from stl_scan s
   where s.userid > 1
   and   s.perm_table_name in ('internal worktable','s3')
```
It returns no results, whereas the correctly capitalized version should return many results:
```
select count(*)
   from stl_scan s
   where s.userid > 1
   and   s.perm_table_name in ('Internal Worktable','S3')
```
Therefore I believe these letters should be capitalized.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
