### PR TITLE
fix cli option for get-cluster-credentials with user auto creation

### DIFF
--- a/doc_source/generating-iam-credentials-cli-api.md
+++ b/doc_source/generating-iam-credentials-cli-api.md
@@ -54,7 +54,7 @@ In this section, you can find steps to programmatically call the GetClusterCrede
    The following example uses the Amazon Redshift CLI with autocreate to generate temporary database credentials for a new user and add the user to the group `example_group`\.
 
    ```
-   aws redshift get-cluster-credentials --cluster-identifier examplecluster --db-user temp_creds_user -–autocreate true --db-name exampledb -–db-groups example_group --duration-seconds 3600
+   aws redshift get-cluster-credentials --cluster-identifier examplecluster --db-user temp_creds_user -–auto-create --db-name exampledb -–db-groups example_group --duration-seconds 3600
    ```
 
    The result is as follows\.


### PR DESCRIPTION
https://docs.aws.amazon.com/cli/latest/reference/redshift/get-cluster-credentials.html

*Description of changes:*
fix cli option for get-cluster-credentials with user auto creation

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
