### PR TITLE
Fix incorrect permission name in Scheduling guide

### DIFF
--- a/doc_source/query-editor-schedule-query.md
+++ b/doc_source/query-editor-schedule-query.md
@@ -68,7 +68,7 @@ For the IAM role that you specify to enable the scheduler to run a query, do the
 
   For more information about how to create an IAM role for EventBridge events, see [Permissions required to use the Amazon EventBridge scheduler](redshift-iam-access-control-identity-based.md#iam-permission-eventbridge-scheduler)\. 
 + Attach the `AmazonRedshiftDataFullAccess` AWS\-managed policy to the IAM role\. 
-+ To allow IAM users to view schedule history, edit the IAM role to add the `sts:AssumRole` permission\. 
++ To allow IAM users to view schedule history, edit the IAM role to add the `sts:AssumeRole` permission\. 
 
 The following is an example of the definition of an IAM role\.
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Fixes a typo: `sts:AssumRole` to `sts:AssumeRole`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
