### PR TITLE
Remove unicode quotes from Spectrum IAM role docs

### DIFF
--- a/doc_source/spectrum-enhanced-vpc.md
+++ b/doc_source/spectrum-enhanced-vpc.md
@@ -34,7 +34,7 @@ The following example bucket policy permits access to the specified bucket only 
      "Sid":"BucketPolicyForSpectrum",
      "Effect":"Allow",
      "Principal": {"AWS": ["arn:aws:iam::123456789012:root"]},
-     "Action":[“s3:GetObject",”s3:List*"],
+     "Action":["s3:GetObject","s3:List*"],
      "Resource":["arn:aws:s3:::examplebucket/*"],
      "Condition":{"StringEquals":{"aws:UserAgent": "AWS Redshift/Spectrum"]}}
    }


### PR DESCRIPTION
Some unicode quotes are breaking syntax highlighting, and are not valid in the example JSON given in the `Bucket access policies` section.

*Issue #, if available:*

*Description of changes:*
Update unicode quotes to ascii quotes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
