### PR TITLE
Update jdbc20-build-connection-url.md

### DIFF
--- a/doc_source/jdbc20-build-connection-url.md
+++ b/doc_source/jdbc20-build-connection-url.md
@@ -40,7 +40,7 @@ jdbc:redshift://my_host:5439/dev?ssl=false?defaultRowFetchSize=100
 The following URL example specifies a log level of 6 and the path for the logs\.
 
 ```
-jdbc:redshift://redshift.amazonaws.com:5439/dev;DSILogLevel=6;LogPath=/home/user/logs";
+jdbc:redshift://redshift.amazonaws.com:5439/dev;DSILogLevel=6;LogPath=/home/user/logs
 ```
 
 Don't duplicate properties in the connection URL\.


### PR DESCRIPTION
There was an extra quotation mark and semi colon at the end of the example URL. Don't think they were supposed to be there

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
