### PR TITLE
Update wrong format for Serverless JDBC Endpoint

### DIFF
--- a/doc_source/authorization-fas-spectrum.md
+++ b/doc_source/authorization-fas-spectrum.md
@@ -36,7 +36,7 @@ Before logging in with federated identity, you must perform several preliminary 
    + Format for an Amazon Redshift provisioned cluster: `jdbc:redshift:iam://<cluster_id>.<unique_suffix>.<region>.redshift.amazonaws.com:<port>/<database_name>`
 
      Example: `jdbc:redshift:iam://test1.12345abcdefg.us-east-1.redshift.amazonaws.com:5439/dev`
-   + Format for Amazon Redshift Serverless: `jdbc:redshift:iam://<workgroup-name>.<account-number>.<aws-region>.redshift-serverless.amazonaws.com:5439:<port>/<database_name>`
+   + Format for Amazon Redshift Serverless: `jdbc:redshift:iam://<workgroup-name>.<account-number>.<aws-region>.redshift-serverless.amazonaws.com:<port>/<database_name>`
 
      Example: `jdbc:redshift:iam://default.123456789012.us-east-1.redshift-serverless.amazonaws.com:5439/dev`
 


### PR DESCRIPTION
The sample format included both a placeholder for the cluster port and the default 5439 port.

I feel like the default 5439 port is a typo and only the placeholder was meant to be there, as the port [may be specified on cluster creation](https://docs.aws.amazon.com/cli/latest/reference/redshift-serverless/create-workgroup.html#:~:text=%2D%2Dport%20(integer),default%20is%205439.)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
